### PR TITLE
WD: Fixed WD crash / PUC. Rolled back deployment convenience messages b/c they may be causi…

### DIFF
--- a/Apps/FlightSoftware/Watchdog/src/stateMachine/RoverStateBase.cpp
+++ b/Apps/FlightSoftware/Watchdog/src/stateMachine/RoverStateBase.cpp
@@ -2002,7 +2002,7 @@ namespace iris
             if (allowUndeploy)
             {
                 unsetDeploy();
-                DPRINTF("WD Released Deployment Interlock in RS...");
+//                DPRINTF("WD Released Deployment Interlock in RS..."); // Removing ... possible having this here causes a PUC
                 SET_RABI_IN_UINT(theContext.m_details.m_resetActionBits, RABI__HDRM_DEPLOY_SIGNAL_POWER_OFF);
             }
             else if (nullptr != response)
@@ -2155,15 +2155,15 @@ namespace iris
                 /* ref: https://docs.google.com/document/d/1dKLlBcIIVo8t1bGu3jNiHobGMavA3I2al0cncj3ZAhE/edit */
                 setDeploy();
                 *(theContext.m_persistentDeployed) = true;
-                DPRINTF("WD Asserting Deployment Interlock in RS...");
+//                DPRINTF("WD Asserting Deployment Interlock in RS..."); // Removing ... possible having this here causes a PUC
                 SET_RABI_IN_UINT(theContext.m_details.m_resetActionBits, RABI__HDRM_DEPLOY_SIGNAL_POWER_ON);
             }
             else if (nullptr != response)
             {
-                DPRINTF(
-                    "WD Deployment preconditions not met. Status: allowOn: %d, allowDeploy: %d.",
-                    allowPowerOn ? 1 : 0,
-                    allowDeploy ? 1 : 0);
+//                DPRINTF(
+//                    "WD Deployment preconditions not met. Status: allowOn: %d, allowDeploy: %d.",
+//                    allowPowerOn ? 1 : 0,
+//                    allowDeploy ? 1 : 0); // Removing ... possible having this here causes a PUC
                 response->statusCode = WD_CMD_MSGS__RESPONSE_STATUS__ERROR_BAD_COMMAND_SEQUENCE;
             }
             break;

--- a/Apps/FlightSoftware/Watchdog/src/stateMachine/RoverStateMission.cpp
+++ b/Apps/FlightSoftware/Watchdog/src/stateMachine/RoverStateMission.cpp
@@ -346,7 +346,7 @@ namespace iris
             deployNotificationResponse.statusCode = WD_CMD_MSGS__RESPONSE_STATUS__DEPLOY;
             sendDeployNotificationResponse = true;
             *(theContext.m_persistentDeployed) = true;
-            DPRINTF("WD Asserting Deployment Interlock in Cmd...");
+//            DPRINTF("WD Asserting Deployment Interlock in Cmd..."); // Removing ... possible having this here causes a PUC
 
             // // Don't allow DebugComms to write to lander anymore
             // DebugComms__registerLanderComms(NULL);


### PR DESCRIPTION
…ng a lockup in the WD leading to a PUC.

- Found a crash when testing deployment bits in Debug_w_Flag in Mission.
    - Crash was caused by WD falling silent then, a few seconds later, booting `Init->EnteringMission->Mission` with the message: **`Reason for last reset: WDTIFG watchdog timeout (PUC)`**
    - Might not be an issue in flight post-deployment since battery latch exists, but that assumes that following this boot path won't cause `LB` to pulse while `BE` is low. `blimp_normalBoot()` is designed to prevent this.
- Crash could be replicated fairly consistently by spamming these commands (either in direct Mission or when booted into Mission):
    - `st-ack`
    - `ReportStatus`
    - `deploy`
    - `deploy-wd-only`
    - `ReportStatus`
    - *usually would have crashed by now*
- Most crashes were observed with Radio off. Could just be a coincidence.
- Crashes were also observed by simpler means:
    - Boot into Mission, `power-off-radio`, wait ~10mins
    - Boot into Mission, `power-off-radio`, wait a few minutes, `ReportStatus`.
- Crashes like this weren't observed during extensive testing before several hours earlier in Herc_Radio_Programming mode. So, cause was either:
    1. Being in Debug_w_Flag instead of Herc_Radio_Programming mode (not likely since this *only* changes a few variable defaults which have been tested via command anyway).
    2. Some of the few untested convenience changes that happened since the last test.

(2.) was assumed and some convenience print statements were rolled back. WD was reflashed into Debug_w_Flag. Seems to have worked...
    - WD was spammed with commands above without crashing.
    - WD was left to sit for >10mins with Radio off without crashing.
    - WD Safety Timer was tested at 5m cutoff (after spamming `st-dec` to get it there) without crashing...
 ... seems like that maybe caused a stack overflow, used up too much memory, or just caused something to block a little bit too long before WD could get back to acking the WD WD (unlikely since it was unresponsive and emitted no data at all after a crash)...